### PR TITLE
Frame semantics parsing stages: clarify validity of __model__, world

### DIFF
--- a/pose_frame_semantics/proposal.md
+++ b/pose_frame_semantics/proposal.md
@@ -1627,7 +1627,7 @@ returning an error code if errors are found during parsing:
 
 6.  ***Check `//model/frame/@attached_to` attribute values:***
     For each `//model/frame`, if the `attached_to` attribute exists and is not
-    an empty string `""`, check that the value of the `attached_to` attribute
+    an empty string `""` or `__model__`, check that the value of the `attached_to` attribute
     matches the name of a sibling link, nested model, joint, or frame.
     The `//frame/@attached_to` value must not match `//frame/@name`,
     as this would cause a graph cycle.
@@ -1702,7 +1702,7 @@ returning an error code if errors are found during parsing:
 8.  ***Check `//pose/@relative_to` attribute values:***
     For each `//pose` that does not correspond to the `__model__` frame (e.g. nested `//model/model/pose`, `//link/pose`,
     `//joint/pose`, `//frame/pose`, `//collision/pose`, `//light/pose`, etc.),
-    if the `relative_to` attribute exists and is not an empty string `""`,
+    if the `relative_to` attribute exists and is not an empty string `""` or `__model__`,
     check that the value of the `relative_to` attribute
     matches the name of a link, nested model, joint, or frame in this model's scope.
     In `libsdformat9`, these checks are performed by
@@ -1845,7 +1845,7 @@ There are *seven* phases for validating the kinematics data in a world:
 
 4.  ***Check `//world/frame/@attached_to` attribute values:***
     For each `//world/frame`, if the `attached_to` attribute exists and is not
-    an empty string `""`, check that the value of the `attached_to` attribute
+    an empty string `""` or `world`, check that the value of the `attached_to` attribute
     matches the name of a sibling model or frame.
     The `//frame/@attached_to` value must not match `//frame/@name`,
     as this would cause a graph cycle.
@@ -1899,7 +1899,7 @@ There are *seven* phases for validating the kinematics data in a world:
 
 6.  ***Check `//pose/@relative_to` attribute values:***
     For each `//model/pose` and `//world/frame/pose`,
-    if the `relative_to` attribute exists and is not an empty string `""`,
+    if the `relative_to` attribute exists and is not an empty string `""` or `world`,
     check that the value of the `relative_to` attribute
     matches the name of a model or frame that is a sibling of the element
     that contains the `//pose`.


### PR DESCRIPTION
# 🦟 Bug fix

Adds missing valid values to attribute checking portion of parsing stages

## Summary

In the parsing stages for checking `@attached_to` and `@relative_to` attribute values, clarify that `__model__` and `world` can be used explicitly in the appropriate context.

Preview: http://sdformat.org/tutorials?tut=pose_frame_semantics_proposal&branch=scpeters/explicit_model_world_references#1-model

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
