### PR TITLE
Add documentation for SDFormat/Gazebo extension to URDF

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -238,6 +238,20 @@
       <skill>intermediate</skill>
     </tutorial>
 
+    <tutorial title="SDFormat extensions to URDF (the 'gazebo' tag)" ref='sdformat_urdf_extensions' type='tutorial'>
+      <markdown version="1.6">urdf/sdf_extensions.md</markdown>
+      <description>
+        Describes how the "gazebo" tag can be used to extend URDF to include SDFormat content.
+        
+      </description>
+      <tags>
+        <tag>model</tag>
+        <tag>urdf</tag>
+        <tag>gazebo</tag>
+      </tags>
+      <skill>intermediate</skill>
+    </tutorial>
+
     <tutorial title="Proposal Procedure and Format" ref='proposal_format' type='documentation'>
       <markdown version="1.7">developers/proposal_format.md</markdown>
       <description>
@@ -297,6 +311,7 @@
         <tutorial>pose_frame_semantics</tutorial>
         <tutorial>composition</tutorial>
         <tutorial>param_passing_tutorial</tutorial>
+        <tutorial>sdformat_urdf_extensions</tutorial>
       </tutorials>
     </category>
 

--- a/urdf/examples/disable_fixed_joint_lumping_example.urdf
+++ b/urdf/examples/disable_fixed_joint_lumping_example.urdf
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<robot name='disable_fixed_joint_lumping_example'>
+  <link name='base_link'>
+    <inertial>
+      <mass value='0.25' />
+      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
+    </inertial>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="2"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name='j1' type='fixed'>
+    <parent link='base_link'/>
+    <child link='end_effector'/>
+    <origin xyz='0 0 1' rpy='0 0 0'/>
+  </joint>
+  <link name='end_effector'>
+    <inertial>
+      <mass value='0.25' />
+      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
+    </inertial>
+    <visual>
+      <origin xyz="2 0 0" rpy="0 0 0"/>
+      <geometry>
+        <cylinder length="1" radius="2"/>
+      </geometry>
+    </visual>
+  </link>
+  <gazebo reference='j1'>
+    <disableFixedJointLumping>true</disableFixedJointLumping>
+  </gazebo>
+</robot>
+

--- a/urdf/examples/disable_fixed_joint_lumping_example.urdf
+++ b/urdf/examples/disable_fixed_joint_lumping_example.urdf
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
+<!--URDF-->
 <robot name='disable_fixed_joint_lumping_example'>
   <link name='base_link'>
     <inertial>

--- a/urdf/examples/fixed_joint_lumping_example.urdf
+++ b/urdf/examples/fixed_joint_lumping_example.urdf
@@ -1,0 +1,33 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<robot name='fixed_joint_lumping_example'>
+  <link name='base_link'>
+    <inertial>
+      <mass value='0.25' />
+      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
+    </inertial>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="2"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name='j1' type='fixed'>
+    <parent link='base_link'/>
+    <child link='end_effector'/>
+    <origin xyz='0 0 1' rpy='0 0 0'/>
+  </joint>
+  <link name='end_effector'>
+    <inertial>
+      <mass value='0.25' />
+      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
+    </inertial>
+    <visual>
+      <origin xyz="2 0 0" rpy="0 0 0"/>
+      <geometry>
+        <cylinder length="1" radius="2"/>
+      </geometry>
+    </visual>
+  </link>
+</robot>
+

--- a/urdf/examples/fixed_joint_lumping_example.urdf
+++ b/urdf/examples/fixed_joint_lumping_example.urdf
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
+<!--URDF-->
 <robot name='fixed_joint_lumping_example'>
   <link name='base_link'>
     <inertial>

--- a/urdf/examples/friction_example.urdf
+++ b/urdf/examples/friction_example.urdf
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<robot name='friction_example'>
+  <link name='base_link'>
+    <inertial>
+      <mass value='0.12' />
+      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
+    </inertial>
+    <collision>
+      <geometry>
+        <sphere radius="2"/>
+      </geometry>
+    </collision>
+  </link>
+  <gazebo reference='base_link'>
+    <mu1>0.25</mu1>
+  </gazebo>
+</robot>
+

--- a/urdf/examples/friction_example.urdf
+++ b/urdf/examples/friction_example.urdf
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
+<!--URDF-->
 <robot name='friction_example'>
   <link name='base_link'>
     <inertial>
@@ -8,6 +9,11 @@
     <collision>
       <geometry>
         <sphere radius="2"/>
+      </geometry>
+    </collision>
+    <collision>
+      <geometry>
+        <cylinder radius="1" length="2"/>
       </geometry>
     </collision>
   </link>

--- a/urdf/examples/joint_example.urdf
+++ b/urdf/examples/joint_example.urdf
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<robot name='joint_example'>
+  <link name='base_link'>
+    <inertial>
+      <mass value='0.12' />
+      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
+    </inertial>
+  </link>
+  <joint name='j1' type='continuous'>
+    <parent link='base_link'/>
+    <child link='end_effector'/>
+    <origin xyz='0 0 1' rpy='0 0 0'/>
+  </joint>
+  <link name='end_effector'>
+    <inertial>
+      <mass value='0.12' />
+      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
+    </inertial>
+  </link>
+  <gazebo reference='j1'>
+    <springReference>0.5</springReference>
+    <springStiffness>0.25</springStiffness>
+  </gazebo>
+</robot>
+

--- a/urdf/examples/joint_example.urdf
+++ b/urdf/examples/joint_example.urdf
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
+<!--URDF-->
 <robot name='joint_example'>
   <link name='base_link'>
     <inertial>

--- a/urdf/examples/link_ref_example.urdf
+++ b/urdf/examples/link_ref_example.urdf
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
+<!--URDF-->
 <robot name='link_ref_example'>
   <link name='base_link'>
     <inertial>

--- a/urdf/examples/link_ref_example.urdf
+++ b/urdf/examples/link_ref_example.urdf
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<robot name='link_ref_example'>
+  <link name='base_link'>
+    <inertial>
+      <mass value='0.1' />
+      <origin rpy='0 0 0' xyz='0 0 0' />
+      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
+    </inertial>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="2"/>
+      </geometry>
+    </collision>
+  </link>
+  <gazebo reference='base_link'>
+    <mu1>0.5</mu1> <!-- Will create collision/surface/friction/ode/mu -->
+
+    <!-- <light> is inserted directly into the link since it is not a special element -->
+    <light name="point_light" type="point">
+      <diffuse>1.0 1.0 1.0 1.0</diffuse>
+      <specular>0.1 0.1 0.1 1.0</specular>
+    </light>
+  </gazebo>
+</robot>
+

--- a/urdf/examples/material_example.urdf
+++ b/urdf/examples/material_example.urdf
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<robot name='material_example'>
+  <link name='base_link'>
+    <inertial>
+      <mass value='0.1' />
+      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
+    </inertial>
+    <visual>
+      <geometry>
+        <sphere radius="2"/>
+      </geometry>
+    </visual>
+  </link>
+  <gazebo reference='base_link'>
+    <material>Gazebo/Orange</material>
+  </gazebo>
+</robot>
+

--- a/urdf/examples/material_example.urdf
+++ b/urdf/examples/material_example.urdf
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
+<!--URDF-->
 <robot name='material_example'>
   <link name='base_link'>
     <inertial>

--- a/urdf/examples/material_visual_example.urdf
+++ b/urdf/examples/material_visual_example.urdf
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
+<!--URDF-->
 <robot name='material_example'>
   <link name='base_link'>
     <inertial>

--- a/urdf/examples/material_visual_example.urdf
+++ b/urdf/examples/material_visual_example.urdf
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<robot name='material_example'>
+  <link name='base_link'>
+    <inertial>
+      <mass value='0.12' />
+      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
+    </inertial>
+    <visual>
+      <geometry>
+        <sphere radius="2"/>
+      </geometry>
+    </visual>
+  </link>
+  <gazebo reference='base_link'>
+    <visual>
+      <material>
+        <diffuse>0 0 1 1 </diffuse>
+      </material>
+    </visual>
+  </gazebo>
+</robot>
+

--- a/urdf/examples/no_ref_example.urdf
+++ b/urdf/examples/no_ref_example.urdf
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
+<!--URDF-->
 <robot name='no_ref_example'>
   <link name='world'/>
   <gazebo>

--- a/urdf/examples/no_ref_example.urdf
+++ b/urdf/examples/no_ref_example.urdf
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<robot name='no_ref_example'>
+  <link name='world'/>
+  <gazebo>
+    <static>true</static>
+    <plugin name='testPlugin' filename='testFileName'/>
+  </gazebo>
+</robot>
+

--- a/urdf/examples/preserve_fixed_joint_example.urdf
+++ b/urdf/examples/preserve_fixed_joint_example.urdf
@@ -21,6 +21,7 @@
   <link name='end_effector'>
     <inertial>
       <mass value='0.25' />
+      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
     </inertial>
     <visual>
       <origin xyz="2 0 0" rpy="0 0 0"/>

--- a/urdf/examples/preserve_fixed_joint_example.urdf
+++ b/urdf/examples/preserve_fixed_joint_example.urdf
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--URDF-->
+<robot name='preserve_fixed_joint_lumping_example'>
+  <link name='base_link'>
+    <inertial>
+      <mass value='0.25' />
+      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
+    </inertial>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="2"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name='j1' type='fixed'>
+    <parent link='base_link'/>
+    <child link='end_effector'/>
+    <origin xyz='0 0 1' rpy='0 0 0'/>
+  </joint>
+  <link name='end_effector'>
+    <inertial>
+      <mass value='0.25' />
+    </inertial>
+    <visual>
+      <origin xyz="2 0 0" rpy="0 0 0"/>
+      <geometry>
+        <cylinder length="1" radius="2"/>
+      </geometry>
+    </visual>
+  </link>
+  <gazebo reference='j1'>
+    <preserveFixedJoint>true</preserveFixedJoint>
+  </gazebo>
+</robot>
+

--- a/urdf/examples/visual_example.urdf
+++ b/urdf/examples/visual_example.urdf
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
+<!--URDF-->
 <robot name='visual_example'>
   <link name='base_link'>
     <inertial>

--- a/urdf/examples/visual_example.urdf
+++ b/urdf/examples/visual_example.urdf
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<robot name='visual_example'>
+  <link name='base_link'>
+    <inertial>
+      <mass value='0.12' />
+      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
+    </inertial>
+    <visual>
+      <geometry>
+        <sphere radius="2"/>
+      </geometry>
+    </visual>
+    <visual>
+      <origin xyz="2 0 0" rpy="0 0 0"/>
+      <geometry>
+        <cylinder length="1" radius="2"/>
+      </geometry>
+    </visual>
+  </link>
+  <gazebo reference='base_link'>
+    <visual>
+      <transparency>0.25</transparency>
+    </visual>
+  </gazebo>
+</robot>
+

--- a/urdf/sdf_extensions.md
+++ b/urdf/sdf_extensions.md
@@ -367,6 +367,46 @@ tag as the `<material>` tag is not directly under `<gazebo>`, but under
 `<visual>`. This `<material>` tag contains child elements as defined in the
 [material](http://sdformat.org/spec?ver=1.9&elem=material) specification.
 
+**Example:**
+
+<include src='https://github.com/azeey/sdf_tutorials/raw/urdf_sdf_extension/urdf/examples/material_visual_example.urdf' />
+
+results in:
+
+```xml
+<!--SDFormat-->
+<sdf version='1.9'>
+  <model name='material_example'>
+    <link name='base_link'>
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>0.12</mass>
+        <inertia>
+          <ixx>0.01</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.01</iyy>
+          <iyz>0</iyz>
+          <izz>0.01</izz>
+        </inertia>
+      </inertial>
+      <visual name='base_link_visual'>
+        <pose>0 0 0 0 0 0</pose>
+        <geometry>
+          <sphere>
+            <radius>2</radius>
+          </sphere>
+        </geometry>
+        <material>
+          <diffuse>0 0 1 1</diffuse>
+        </material>
+      </visual>
+    </link>
+  </model>
+</sdf>
+```
+
+where the `<diffuse>` tag has been added to the visual of `base_link`.
 
 > **Warning:**
 At the time of writing, there is

--- a/urdf/sdf_extensions.md
+++ b/urdf/sdf_extensions.md
@@ -319,14 +319,14 @@ referenced link, similar to the behavior of `<visual>` and `<collision>`
 
 **Example:**
 
-<include src='https://github.com/azeey/sdf_tutorials/raw/urdf_sdf_extension/urdf/examples/link_ref_example.urdf' />
+<include src='https://github.com/azeey/sdf_tutorials/raw/urdf_sdf_extension/urdf/examples/material_example.urdf' />
 
 results in:
 
 ```xml
 <!--SDFormat-->
 <sdf version='1.9'>
-  <model name='link_ref_example'>
+  <model name='material_example'>
     <link name='base_link'>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
@@ -357,7 +357,6 @@ results in:
     </link>
   </model>
 </sdf>
-
 ```
 
 This tag is only relevant when using Gazebo-classic as the new version of
@@ -684,14 +683,23 @@ results in:
         <pose>0 0 0 0 0 0</pose>
         <mass>0.25</mass>
         <inertia>
-          <ixx>0</ixx>
+          <ixx>0.01</ixx>
           <ixy>0</ixy>
           <ixz>0</ixz>
-          <iyy>0</iyy>
+          <iyy>0.01</iyy>
           <iyz>0</iyz>
-          <izz>0</izz>
+          <izz>0.01</izz>
         </inertia>
       </inertial>
+      <visual name='end_effector_visual'>
+        <pose>2 0 0 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>1</length>
+            <radius>2</radius>
+          </cylinder>
+        </geometry>
+      </visual>
     </link>
   </model>
 </sdf>

--- a/urdf/sdf_extensions.md
+++ b/urdf/sdf_extensions.md
@@ -1,0 +1,822 @@
+# SDFormat extensions to URDF (the `<gazebo>` tag)
+
+When URDF files are loaded by Gazebo (both Gazebo-classic and the new Gazebo),
+the URDF content is first converted to SDFormat before being processed by
+Gazebo. Users who to modify the resulting SDFormat output to include SDFormat
+specific elements may do so using the `<gazebo>` tag in the original URDF file.
+This is known as the Gazebo extension to the [URDF
+specification](http://wiki.ros.org/urdf/XML) (see
+http://wiki.ros.org/urdf/XML/Gazebo)
+
+The URDF to SDFormat conversion usually happens automatically without users
+observing the resultang SDFormat file. To diagnose any issues that might come
+up during the conversion, the tool 
+
+```gz sdf -p <path to urdf file>```
+
+can be used to convert the URDF file to SDFormat that can be inspected by the user.
+
+The following is the documentation of the various tags available under
+`<gazebo>` and their corresponding effect on the SDFormat output. While some of
+the content included here is also available in the ["Using a URDF in
+Gazebo"](http://gazebosim.org/tutorials?tut=ros_urdf&cat=connect_ros) tutorial
+of Gazebo-classic, this document should provide a more complete discussion of
+the extension, especially regarding fixed joint lumping.
+
+
+## `<gazebo>` Elements For `<robot>`
+`<gazebo>` tag without a `reference` attribute applies to the SDFormat `<model>`
+that gets generated from the `<robot>` URDF tag. All elements in the `<gazebo>`
+tag are inserted into the SDF `<model>` tag for the generated SDF.
+
+**Example:**
+
+```xml
+<!--URDF-->
+<robot name='no_ref_example'>
+  <link name='world'/>
+  <gazebo>
+    <static>true</static>
+    <plugin name='testPlugin' filename='testFileName'/>
+  </gazebo>
+</robot>
+```
+
+results in:
+
+```xml
+<!--SDFormat-->
+<sdf version='1.9'>
+  <model name='no_ref_example'>
+    <static>true</static>
+    <plugin name='testPlugin' filename='testFileName'/>
+  </model>
+</sdf>
+```
+
+## `<gazebo>` Elements For Links
+
+When using the `<gazebo>` extension for links, the name of the link has to be
+specified in the `reference` attribute. There are a number of special tags that
+modify the values of elements or attributes in the generated SDFormat file. Any
+tag that is not listed in the table below will be directly inserted into the
+the corresponding `<link>` element in the SDFormat output.
+
+**Table of elements with special meaning:**
+
+<table>
+  <tr>
+    <th>Name</th>
+    <th>Type</th>
+    <th>Description</th>
+    <th>Corresponding SDFormat element</th>
+  </tr>
+  <tr>
+    <td>turnGravityOff</td>
+    <td>bool</td>
+    <td>A value of "true" turns gravity off. Alternatively, <code>gravity</code> (with opposite boolean value) can be used via blob insertion</td>
+    <td><code>gravity</code></td>
+  </tr>
+  <tr>
+    <td>dampingFactor</td>
+    <td>double</td>
+    <td>Exponential velocity decay of the link velocity - takes the value and multiplies the previous link velocity by (1-dampingFactor).</td>
+    <td><code>velocity_decay/linear</code> and <code>velocity_decay/angular</code></td>
+  </tr>
+  <tr>
+    <td>maxVel</td>
+    <td>double</td>
+    <td>maximum contact correction velocity truncation term.</td>
+    <td><code>collision/surface/contact/ode/max_vel</code></td>
+  </tr>
+  <tr>
+    <td>minDepth</td>
+    <td>double</td>
+    <td>minimum allowable depth before contact correction impulse is applied</td>
+    <td><code>collision/surface/contact/ode/min_depth</code></td>
+  </tr>
+  <tr>
+    <td>mu1</td>
+    <td rowspan="2">double</td>
+    <td rowspan="2">Friction coefficients μ for the principal contact directions along the contact surface as defined by the
+      <a href="http://www.ode.org">Open Dynamics Engine (ODE)</a>
+      (see parameter descriptions in <a href="http://www.ode.org/ode-latest-userguide.html#sec_7_3_7">ODE's user guide</a>)
+    </td>
+    <td><code>collision/surface/friction/ode/mu</code></td>
+  </tr>
+  <tr>
+    <td>mu2</td>
+    <td><code>collision/surface/friction/ode/mu2</code></td>
+  </tr>
+  <tr>
+    <td>fdir1</td>
+    <td>vector</td>
+    <td>3-tuple specifying direction of mu1 in the collision local reference frame.</td>
+    <td><code>collision/surface/friction/ode/fdir1</code></td>
+  </tr>
+  <tr>
+    <td>kp</td>
+    <td rowspan="2">double</td>
+    <td rowspan="2">Contact stiffness k_p and damping k_d for rigid body contacts as defined by ODE
+      (<a href="http://www.ode.org/ode-latest-userguide.html#sec_7_3_7">ODE uses erp and cfm</a>
+      but there is a
+      <a href="https://github.com/osrf/gazebo/blob/gazebo9/gazebo/physics/ode/ODEJoint.cc">mapping between erp/cfm and stiffness/damping</a>)
+    </td>
+    <td><code>collision/surface/contact/ode/kp</code></td>
+  </tr>
+  <tr>
+    <td>kd</td>
+    <td><code>collision/surface/contact/ode/kd</code></td>
+  </tr>
+  <tr>
+    <td>selfCollide</td>
+    <td>bool</td>
+    <td>If true, the link can collide with other links in the model.</td>
+    <td><code>self_collide</code></td>
+  </tr>
+  <tr>
+    <td>maxContacts</td>
+    <td>int</td>
+    <td>Maximum number of contacts allowed between two entities. This value overrides the max_contacts element defined in physics.</td>
+    <td><code>collision/max_contacts</code></td>
+  </tr>
+  <tr>
+    <td>laserRetro</td>
+    <td>double</td>
+    <td>intensity value returned by laser sensor.</td>
+    <td><code>collision/laser_retro</code></td>
+  </tr>
+  <tr>
+    <td>visual</td>
+    <td>element</td>
+    <td>The content of the element will be inserted into each <code>visual</code> of the SDFormat link</td>
+    <td><code>visual</code></td>
+  </tr>
+  <tr>
+    <td>material</td>
+    <td>element</td>
+    <td>The content of the element will be inserted into each <code>material</code> of the SDFormat link</td>
+    <td><code>visual/material</code></td>
+  </tr>
+  <tr>
+    <td>collision</td>
+    <td>element</td>
+    <td>The content of the element will be inserted into each <code>collision</code> of the SDFormat link</td>
+    <td><code>collision</code></td>
+  </tr>
+</table>
+
+> **Note:** The XPath used in the "Corresponding SDFormat element" column is relative to the link element.
+
+**Example:**
+
+The following shows how to set the the first coefficient of friction for all
+`<collision>` elements in a link
+
+```xml
+<!--URDF-->
+<robot name='friction_example'>
+  <link name='base_link'>
+    <inertial>
+      <mass value='0.12' />
+      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
+    </inertial>
+    <collision>
+      <geometry>
+        <sphere radius="2"/>
+      </geometry>
+    </collision>
+  </link>
+  <gazebo reference='base_link'>
+    <mu1>0.25</mu1>
+  </gazebo>
+</robot>
+```
+
+This creates the element `//surface/friction/ode/mu` in the collision element of the referenced link.
+
+```xml
+<!--SDFormat-->
+<sdf version='1.9'>
+  <model name='friction_example'>
+    <link name='base_link'>
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>0.12</mass>
+        <inertia>
+          <ixx>0.01</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.01</iyy>
+          <iyz>0</iyz>
+          <izz>0.01</izz>
+        </inertia>
+      </inertial>
+      <collision name='base_link_collision'>
+        <pose>0 0 0 0 0 0</pose>
+        <geometry>
+          <sphere>
+            <radius>2</radius>
+          </sphere>
+        </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode>
+              <mu>0.25</mu>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+    </link>
+  </model>
+</sdf>
+```
+
+## Special meaning for `<visual>`, `<collision>`, and `<material>`
+
+The `<visual>` and `<collision>` are meant to update existing visuals and
+collisions in the URDF as they get converted to SDFormat. At the time of
+writing, these tags do not insert new visuals or collision elements into the
+referenced link. Note also that these tags affect all visuals and collisions,
+respectively, found in the referenced link.
+
+**Example:**
+
+Given the following URDF file with two visuals, the `<gazebo>` extension
+applies the element `<transparency>` to each visual in `base_link`.
+
+```xml
+<!--URDF-->
+<robot name='visual_example'>
+  <link name='base_link'>
+    <inertial>
+      <mass value='0.12' />
+      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
+    </inertial>
+    <visual>
+      <geometry>
+        <sphere radius="2"/>
+      </geometry>
+    </visual>
+    <visual>
+      <origin xyz="2 0 0" rpy="0 0 0"/>
+      <geometry>
+        <cylinder length="1" radius="2"/>
+      </geometry>
+    </visual>
+  </link>
+  <gazebo reference='base_link'>
+    <visual>
+      <transparency>0.25</transparency>
+    </visual>
+  </gazebo>
+</robot>
+```
+
+Converts to the following SDFormat
+
+```xml
+<!--SDFormat-->
+<sdf version='1.9'>
+  <model name='visual_example'>
+    <link name='base_link'>
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>0.12</mass>
+        <inertia>
+          <ixx>0.01</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.01</iyy>
+          <iyz>0</iyz>
+          <izz>0.01</izz>
+        </inertia>
+      </inertial>
+      <visual name='base_link_visual'>
+        <pose>0 0 0 0 0 0</pose>
+        <geometry>
+          <sphere>
+            <radius>2</radius>
+          </sphere>
+        </geometry>
+        <transparency>0.25</transparency>
+      </visual>
+      <visual name='base_link_visual_1'>
+        <pose>2 0 0 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>1</length>
+            <radius>2</radius>
+          </cylinder>
+        </geometry>
+        <transparency>0.25</transparency>
+      </visual>
+    </link>
+  </model>
+</sdf>
+
+```
+
+
+
+The `<material>` tag, when used direclty under the `<gazebo>` tag, i.e
+`//gazebo/material`, accepts a string value of the name of a material defined
+in a Gazebo-classic's material [script](
+https://github.com/gazebosim/gazebo-classic/blob/d0c34b8a5d6bc9a3271000fb1baeb3f8d9f43afa/media/materials/scripts/gazebo.material).
+Examples include colors like `Gazebo/SkyBlue` as well as textures such as
+`Gazebo/WoodFloor`. The `<material>` tag affects all visuals found in the
+referenced link, similar to the behavior of `<visual>` and `<collision>`
+
+**Example:**
+
+```xml
+<!--URDF-->
+<robot name='link_ref_example'>
+  <link name='base_link'>
+    <inertial>
+      <mass value='0.1' />
+      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
+    </inertial>
+    <visual>
+      <geometry>
+        <sphere radius="2"/>
+      </geometry>
+    </visual>
+  </link>
+  <gazebo reference='base_link'>
+    <material>Gazebo/Orange</material>
+  </gazebo>
+</robot>
+
+```
+
+results in:
+
+```xml
+<!--SDFormat-->
+<sdf version='1.9'>
+  <model name='link_ref_example'>
+    <link name='base_link'>
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>0.10000000000000001</mass>
+        <inertia>
+          <ixx>0.01</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.01</iyy>
+          <iyz>0</iyz>
+          <izz>0.01</izz>
+        </inertia>
+      </inertial>
+      <visual name='base_link_visual'>
+        <pose>0 0 0 0 0 0</pose>
+        <geometry>
+          <sphere>
+            <radius>2</radius>
+          </sphere>
+        </geometry>
+        <material>
+          <script>
+            <name>Gazebo/Orange</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+          </script>
+        </material>
+      </visual>
+    </link>
+  </model>
+</sdf>
+
+```
+
+This tag is only relevant when using Gazebo-classic as the new version of
+Gazebo does not use material scripts. However, it is still possible to change
+the appearance of visuals that is compatible with the new Gazebo and this is by
+using the `//gazebo/visual/material` tag. Note the difference from the previous
+tag as the `<material>` tag is not directly under `<gazebo>`, but under
+`<visual>`. This `<material>` tag contains child elements as defined in the
+[material](http://sdformat.org/spec?ver=1.9&elem=material) specification.
+
+
+> **Warning:**
+At the time of writing, there is
+a [bug](https://github.com/gazebosim/sdformat/issues/333) in the URDF to
+SDFormat converter that behaves incorrectly when `<visual>` and `<collision>`
+tags in the **URDF** file have names.
+
+### `<gazebo>` Elements For Joints
+
+When using the `<gazebo>` extension for joints, the name of the joint has to be
+specified in the `reference` attribute. There are a number of special tags that
+modify the values of elements or attributes in the generated SDFormat file. Any
+tag that is not listed in the table below will be directly inserted into the
+the corresponding `<joint>` element in the SDFormat output.
+
+
+**Table of elements with special meaning:**
+
+<table>
+  <tr>
+    <th>Name</th>
+    <th>Type</th>
+    <th>Description</th>
+    <th>Corresponding SDFormat element</th>
+  </tr>
+  <tr>
+    <td>stopCfm</td>
+    <td rowspan="2">double</td>
+    <td rowspan="2">Joint stop constraint force mixing (cfm) and error reduction parameter (erp) used by ODE</td>
+    <td><code>physics/ode/limit/cfm</code></td>
+  </tr>
+  <tr>
+    <td>stopErp</td>
+    <td><code>physics/ode/limit/erp</code></td>
+  </tr>
+  <tr>
+    <td>provideFeedback</td>
+    <td>bool</td>
+    <td>Allows joints to publish their wrench data (force-torque) via a Gazebo plugin</td>
+    <td><code>physics/provide_feedback</code> and <code>physics/ode/provide_feedback</code></td>
+  </tr>
+  <tr>
+    <td>implicitSpringDamper</td>
+    <td>bool</td>
+    <td>If this flag is set to true, ODE will use ERP and CFM to simulate damping.
+    This is a more stable numerical method for damping than the default damping tag.
+    The cfmDamping element is deprecated and should be changed to implicitSpringDamper.
+    </td>
+    <td><code>physics/ode/implicit_spring_damper</code></td>
+  </tr>
+  <tr>
+    <td>springStiffness</td>
+    <td>double</td>
+    <td>Spring stiffness in N/m.</td>
+    <td><code>axis/dynamics/spring_stiffness</code></td>
+  </tr>
+  <tr>
+    <td>springReference</td>
+    <td>double</td>
+    <td>Equilibrium position for the spring.
+    <td><code>axis/dynamics/spring_reference</code></td>
+  </td>
+  </tr>
+  <tr>
+    <td>fudgeFactor</td>
+    <td>double</td>
+    <td>Scale the excess for in a joint motor at joint limits. Should be between zero and one.</td>
+    <td><code>physics/ode/fudge_factor</code></td>
+  </tr>
+  <tr>
+    <td>disableFixedJointLumping</td>
+    <td>bool</td>
+    <td>By default, fixed joints in the URDF are "lumped", meaning that the contents of the child link are merged with the parent link with appropriate pose offsets and the joint is discarded. Setting this to <code>true</code> disables fixed joint lumping</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>preserveFixedJoint</td>
+    <td>bool</td>
+    <td>By default, when <code>disableFixedJointLumping</code> is set to <code>true</code>, fixed joints in the URDF are converted to revolute joints with limits set to 0 in the SDFormat file. Setting this to <code>true</code> will cause "fixed" joints to be used in the SDFormat output.</td>
+    <td></td>
+  </tr>
+</table>
+
+> **Note:** The XPath used in the "Corresponding SDFormat element" column is relative to the joint element.
+
+
+**Example:**
+The spring reference and stiffness of a joint can be set using
+`<springReference>` and `<springStiffness>` respectively.
+
+```xml
+<!--URDF-->
+<robot name='joint_example'>
+  <link name='base_link'>
+    <inertial>
+      <mass value='0.12' />
+      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
+    </inertial>
+  </link>
+  <joint name='j1' type='continuous'>
+    <parent link='base_link'/>
+    <child link='end_effector'/>
+    <origin xyz='0 0 1' rpy='0 0 0'/>
+  </joint>
+  <link name='end_effector'>
+    <inertial>
+      <mass value='0.12' />
+      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
+    </inertial>
+  </link>
+  <gazebo reference='j1'>
+    <springReference>0.5</springReference>
+    <springStiffness>0.25</springStiffness>
+  </gazebo>
+</robot>
+```
+
+This creates the elements `//axis/dynamics/spring_reference`
+and `//axis/dynamics//spring_stiffness` in the referenced joint
+of the SDFormat output.
+
+```xml
+<!--SDFormat-->
+<sdf version='1.9'>
+  <model name='joint_example'>
+    <link name='base_link'>
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>0.12</mass>
+        <inertia>
+          <ixx>0.01</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.01</iyy>
+          <iyz>0</iyz>
+          <izz>0.01</izz>
+        </inertia>
+      </inertial>
+    </link>
+    <joint name='j1' type='revolute'>
+      <pose relative_to='base_link'>0 0 1 0 0 0</pose>
+      <parent>base_link</parent>
+      <child>end_effector</child>
+      <axis>
+        <xyz>1 0 0</xyz>
+        <limit>
+          <lower>-10000000000000000</lower>
+          <upper>10000000000000000</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0.5</spring_reference>
+          <spring_stiffness>0.25</spring_stiffness>
+        </dynamics>
+      </axis>
+      <physics>
+        <ode>
+          <limit>
+            <cfm>0</cfm>
+            <erp>0.20000000000000001</erp>
+          </limit>
+        </ode>
+      </physics>
+    </joint>
+    <link name='end_effector'>
+      <pose relative_to='j1'>0 0 0 0 0 0</pose>
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>0.12</mass>
+        <inertia>
+          <ixx>0.01</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.01</iyy>
+          <iyz>0</iyz>
+          <izz>0.01</izz>
+        </inertia>
+      </inertial>
+    </link>
+  </model>
+</sdf>
+```
+
+### Fixed joint lumping
+
+Fixed joint lumping (aka joint reduction), in the URDF to SDFormat conversion
+is the process of taking the child link of a *fixed* joint and merging all of
+its contents into the parent link. The process preserves the total mass of the
+two links and computes the center of mass and moment of inertia of the
+resultant link. All `visual` and `collision` elements present in the child link
+are moved to the parent link with appropriate pose offsets. The fixed joint
+itself is discarded and does not appear in the SDFormat output. As of
+`libsdformat 9.9.0` `frame` elements that represent the discarded joint and
+child link are generated to preserve their pose information.
+
+Fixed joint lumping is an optimization that benefits maximal coordinate physics
+engines by reducing the number of constraints needed to simulate the model.
+
+Fixed joint lumping is enabled by default, but can be disabled by setting
+`disableFixedJointLumping` to `true`.
+
+> **Warning:** Disabling joint lumping (`disableFixedJointLumping=true`) should
+only be done when both parent and child links have positive mass and
+corresponding `<inertial>` elements.
+
+**Example:** The following URDF demonstrates fixed joint lumping where the
+resulting SDFormat output only has one link
+
+```xml
+<!--URDF-->
+<robot name='fixed_joint_lumping_example'>
+  <link name='base_link'>
+    <inertial>
+      <mass value='0.25' />
+      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
+    </inertial>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="2"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name='j1' type='fixed'>
+    <parent link='base_link'/>
+    <child link='end_effector'/>
+    <origin xyz='0 0 1' rpy='0 0 0'/>
+  </joint>
+  <link name='end_effector'>
+    <inertial>
+      <mass value='0.25' />
+      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
+    </inertial>
+    <visual>
+      <origin xyz="2 0 0" rpy="0 0 0"/>
+      <geometry>
+        <cylinder length="1" radius="2"/>
+      </geometry>
+    </visual>
+  </link>
+</robot>
+```
+
+results in:
+
+```xml 
+<!--SDFormat-->
+<sdf version='1.9'>
+  <model name='fixed_joint_lumping_example'>
+    <link name='base_link'>
+      <inertial>
+        <pose>0 0 0.5 0 0 0</pose>
+        <mass>0.5</mass>
+        <inertia>
+          <ixx>0.14499999999999999</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.14499999999999999</iyy>
+          <iyz>0</iyz>
+          <izz>0.02</izz>
+        </inertia>
+      </inertial>
+      <collision name='base_link_collision'>
+        <pose>0 0 0 0 0 0</pose>
+        <geometry>
+          <sphere>
+            <radius>2</radius>
+          </sphere>
+        </geometry>
+      </collision>
+      <visual name='base_link_fixed_joint_lump__end_effector_visual'>
+        <pose>2 0 1 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>1</length>
+            <radius>2</radius>
+          </cylinder>
+        </geometry>
+      </visual>
+    </link>
+    <frame name='j1' attached_to='base_link'>
+      <pose>0 0 1 0 -0 0</pose>
+    </frame>
+    <frame name='end_effector' attached_to='j1'/>
+  </model>
+</sdf>
+```
+
+Note that the mass of `base_link` is the sum of the masses of the original
+`base_link` and `end_effector` links. The `visual` element of `end_effector`
+has been merged into `base_link` with a pose value that takes into account the
+pose of the original `end_effector` link and joint `j1` as well as the pose of
+the original `visual`.
+
+**Example:** The same example above is repeated, but with fixed joint lumping
+disabled (`disableFixedJointLumping=true`).
+
+```xml
+<!--URDF-->
+<robot name='disable_fixed_joint_lumping_example'>
+  <link name='base_link'>
+    <inertial>
+      <mass value='0.25' />
+      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
+    </inertial>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="2"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name='j1' type='fixed'>
+    <parent link='base_link'/>
+    <child link='end_effector'/>
+    <origin xyz='0 0 1' rpy='0 0 0'/>
+  </joint>
+  <link name='end_effector'>
+    <inertial>
+      <mass value='0.25' />
+      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
+    </inertial>
+    <visual>
+      <origin xyz="2 0 0" rpy="0 0 0"/>
+      <geometry>
+        <cylinder length="1" radius="2"/>
+      </geometry>
+    </visual>
+  </link>
+  <gazebo reference='j1'>
+    <disableFixedJointLumping>true</disableFixedJointLumping>
+  </gazebo>
+</robot>
+```
+
+results in:
+
+```xml
+<!--SDFormat-->
+<sdf version='1.9'>
+  <model name='disable_fixed_joint_lumping_example'>
+    <link name='base_link'>
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>0.25</mass>
+        <inertia>
+          <ixx>0.01</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.01</iyy>
+          <iyz>0</iyz>
+          <izz>0.01</izz>
+        </inertia>
+      </inertial>
+      <collision name='base_link_collision'>
+        <pose>0 0 0 0 0 0</pose>
+        <geometry>
+          <sphere>
+            <radius>2</radius>
+          </sphere>
+        </geometry>
+      </collision>
+    </link>
+    <joint name='j1' type='revolute'>
+      <pose relative_to='base_link'>0 0 1 0 0 0</pose>
+      <parent>base_link</parent>
+      <child>end_effector</child>
+      <axis>
+        <limit>
+          <lower>0</lower>
+          <upper>0</upper>
+        </limit>
+        <dynamics>
+          <damping>0</damping>
+          <friction>0</friction>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+        <xyz>0 0 1</xyz>
+      </axis>
+      <physics>
+        <ode>
+          <limit>
+            <cfm>0</cfm>
+            <erp>0.20000000000000001</erp>
+          </limit>
+        </ode>
+      </physics>
+    </joint>
+    <link name='end_effector'>
+      <pose relative_to='j1'>0 0 0 0 0 0</pose>
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>0.25</mass>
+        <inertia>
+          <ixx>0.01</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.01</iyy>
+          <iyz>0</iyz>
+          <izz>0.01</izz>
+        </inertia>
+      </inertial>
+      <visual name='end_effector_visual'>
+        <pose>2 0 0 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>1</length>
+            <radius>2</radius>
+          </cylinder>
+        </geometry>
+      </visual>
+    </link>
+  </model>
+</sdf>
+```
+
+Here, the link `end_effector` is still present in the SDFormat output with mass
+and inertia equal to the URDF `end_effector` link. The `visual` of
+`end_effector` is also still present in the `end_effector` link of the SDFormat
+output.

--- a/urdf/sdf_extensions.md
+++ b/urdf/sdf_extensions.md
@@ -2,15 +2,15 @@
 
 When URDF files are loaded by Gazebo (both Gazebo-classic and the new Gazebo),
 the URDF content is first converted to SDFormat before being processed by
-Gazebo. Users who to modify the resulting SDFormat output to include SDFormat
+Gazebo. Users who want to modify the resulting SDFormat output to include SDFormat
 specific elements may do so using the `<gazebo>` tag in the original URDF file.
 This is known as the Gazebo extension to the [URDF
 specification](http://wiki.ros.org/urdf/XML) (see
 http://wiki.ros.org/urdf/XML/Gazebo)
 
 The URDF to SDFormat conversion usually happens automatically without users
-observing the resultang SDFormat file. To diagnose any issues that might come
-up during the conversion, the tool 
+observing the resulting SDFormat file. To diagnose any issues that might come
+up during the conversion, the tool
 
 ```gz sdf -p <path to urdf file>```
 
@@ -31,16 +31,7 @@ tag are inserted into the SDF `<model>` tag for the generated SDF.
 
 **Example:**
 
-```xml
-<!--URDF-->
-<robot name='no_ref_example'>
-  <link name='world'/>
-  <gazebo>
-    <static>true</static>
-    <plugin name='testPlugin' filename='testFileName'/>
-  </gazebo>
-</robot>
-```
+<include src='https://github.com/azeey/sdf_tutorials/raw/urdf_sdf_extension/urdf/examples/no_ref_example.urdf' />
 
 results in:
 
@@ -60,7 +51,8 @@ When using the `<gazebo>` extension for links, the name of the link has to be
 specified in the `reference` attribute. There are a number of special tags that
 modify the values of elements or attributes in the generated SDFormat file. Any
 tag that is not listed in the table below will be directly inserted into the
-the corresponding `<link>` element in the SDFormat output.
+corresponding `<link>` element in the SDFormat output. This direct insertion is
+sometimes referred to as blob insertion.
 
 **Table of elements with special meaning:**
 
@@ -86,13 +78,19 @@ the corresponding `<link>` element in the SDFormat output.
   <tr>
     <td>maxVel</td>
     <td>double</td>
-    <td>maximum contact correction velocity truncation term.</td>
+    <td>Maximum contact correction velocity truncation term. (See the 
+    Gazebo-classic tutorial on <a 
+    href="https://classic.gazebosim.org/tutorials?tut=physics_params&cat=physics#Constraintsparameters">Constraints 
+    Parameters</a> for more detail)</td>
     <td><code>collision/surface/contact/ode/max_vel</code></td>
   </tr>
   <tr>
     <td>minDepth</td>
     <td>double</td>
-    <td>minimum allowable depth before contact correction impulse is applied</td>
+    <td>Minimum allowable depth before contact correction impulse is applied. 
+    (See the Gazebo-classic tutorial on <a 
+    href="https://classic.gazebosim.org/tutorials?tut=physics_params&cat=physics#Constraintsparameters">Constraints 
+    Parameters</a> for more detail)</td>
     <td><code>collision/surface/contact/ode/min_depth</code></td>
   </tr>
   <tr>
@@ -100,7 +98,11 @@ the corresponding `<link>` element in the SDFormat output.
     <td rowspan="2">double</td>
     <td rowspan="2">Friction coefficients μ for the principal contact directions along the contact surface as defined by the
       <a href="http://www.ode.org">Open Dynamics Engine (ODE)</a>
-      (see parameter descriptions in <a href="http://www.ode.org/ode-latest-userguide.html#sec_7_3_7">ODE's user guide</a>)
+      (see parameter descriptions in <a 
+      href="http://www.ode.org/ode-latest-userguide.html#sec_7_3_7">ODE's user 
+      guide</a> and the Gazebo-classic tutorial on <a 
+      href="https://classic.gazebosim.org/tutorials?tut=physics_params&cat=physics#Frictionparameters">Friction 
+      Parameters</a> for more detail)
     </td>
     <td><code>collision/surface/friction/ode/mu</code></td>
   </tr>
@@ -111,7 +113,10 @@ the corresponding `<link>` element in the SDFormat output.
   <tr>
     <td>fdir1</td>
     <td>vector</td>
-    <td>3-tuple specifying direction of mu1 in the collision local reference frame.</td>
+    <td>3-tuple specifying direction of mu1 in the collision local reference 
+    frame. (See the Gazebo-classic tutorial on <a 
+    href="https://classic.gazebosim.org/tutorials?tut=physics_params&cat=physics#Frictionparameters">Friction 
+    Parameters</a> for more detail)</td>
     <td><code>collision/surface/friction/ode/fdir1</code></td>
   </tr>
   <tr>
@@ -120,7 +125,12 @@ the corresponding `<link>` element in the SDFormat output.
     <td rowspan="2">Contact stiffness k_p and damping k_d for rigid body contacts as defined by ODE
       (<a href="http://www.ode.org/ode-latest-userguide.html#sec_7_3_7">ODE uses erp and cfm</a>
       but there is a
-      <a href="https://github.com/osrf/gazebo/blob/gazebo9/gazebo/physics/ode/ODEJoint.cc">mapping between erp/cfm and stiffness/damping</a>)
+      <a 
+      href="https://github.com/osrf/gazebo/blob/gazebo9/gazebo/physics/ode/ODEJoint.cc">mapping 
+      between erp/cfm and stiffness/damping</a>. Also see See the 
+      Gazebo-classic tutorial on <a 
+      href="https://classic.gazebosim.org/tutorials?tut=physics_params&cat=physics#Contactparameters">Contact 
+      Parameters</a> for more detail)
     </td>
     <td><code>collision/surface/contact/ode/kp</code></td>
   </tr>
@@ -137,13 +147,15 @@ the corresponding `<link>` element in the SDFormat output.
   <tr>
     <td>maxContacts</td>
     <td>int</td>
-    <td>Maximum number of contacts allowed between two entities. This value overrides the max_contacts element defined in physics.</td>
+    <td>Maximum number of contacts allowed between two entities. This value overrides the max_contacts element defined in physics.(See the Gazebo-classic tutorial on <a 
+    href="https://classic.gazebosim.org/tutorials?tut=physics_params&cat=physics#Contactparameters">Contact 
+    Parameters</a> for more detail)</td>
     <td><code>collision/max_contacts</code></td>
   </tr>
   <tr>
     <td>laserRetro</td>
     <td>double</td>
-    <td>intensity value returned by laser sensor.</td>
+    <td>Intensity value returned by laser sensor.</td>
     <td><code>collision/laser_retro</code></td>
   </tr>
   <tr>
@@ -170,28 +182,10 @@ the corresponding `<link>` element in the SDFormat output.
 
 **Example:**
 
-The following shows how to set the the first coefficient of friction for all
+The following shows how to set the first coefficient of friction for all
 `<collision>` elements in a link
 
-```xml
-<!--URDF-->
-<robot name='friction_example'>
-  <link name='base_link'>
-    <inertial>
-      <mass value='0.12' />
-      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
-    </inertial>
-    <collision>
-      <geometry>
-        <sphere radius="2"/>
-      </geometry>
-    </collision>
-  </link>
-  <gazebo reference='base_link'>
-    <mu1>0.25</mu1>
-  </gazebo>
-</robot>
-```
+<include src='https://github.com/azeey/sdf_tutorials/raw/urdf_sdf_extension/urdf/examples/friction_example.urdf' />
 
 This creates the element `//surface/friction/ode/mu` in the collision element of the referenced link.
 
@@ -230,6 +224,25 @@ This creates the element `//surface/friction/ode/mu` in the collision element of
           </friction>
         </surface>
       </collision>
+      <collision name='base_link_collision_1'>
+        <pose>0 0 0 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>2</length>
+            <radius>1</radius>
+          </cylinder>
+        </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode>
+              <mu>0.25</mu>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
     </link>
   </model>
 </sdf>
@@ -248,33 +261,7 @@ respectively, found in the referenced link.
 Given the following URDF file with two visuals, the `<gazebo>` extension
 applies the element `<transparency>` to each visual in `base_link`.
 
-```xml
-<!--URDF-->
-<robot name='visual_example'>
-  <link name='base_link'>
-    <inertial>
-      <mass value='0.12' />
-      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
-    </inertial>
-    <visual>
-      <geometry>
-        <sphere radius="2"/>
-      </geometry>
-    </visual>
-    <visual>
-      <origin xyz="2 0 0" rpy="0 0 0"/>
-      <geometry>
-        <cylinder length="1" radius="2"/>
-      </geometry>
-    </visual>
-  </link>
-  <gazebo reference='base_link'>
-    <visual>
-      <transparency>0.25</transparency>
-    </visual>
-  </gazebo>
-</robot>
-```
+<include src='https://github.com/azeey/sdf_tutorials/raw/urdf_sdf_extension/urdf/examples/visual_example.urdf' />
 
 Converts to the following SDFormat
 
@@ -322,7 +309,7 @@ Converts to the following SDFormat
 
 
 
-The `<material>` tag, when used direclty under the `<gazebo>` tag, i.e
+The `<material>` tag, when used directly under the `<gazebo>` tag, i.e
 `//gazebo/material`, accepts a string value of the name of a material defined
 in a Gazebo-classic's material [script](
 https://github.com/gazebosim/gazebo-classic/blob/d0c34b8a5d6bc9a3271000fb1baeb3f8d9f43afa/media/materials/scripts/gazebo.material).
@@ -332,26 +319,7 @@ referenced link, similar to the behavior of `<visual>` and `<collision>`
 
 **Example:**
 
-```xml
-<!--URDF-->
-<robot name='link_ref_example'>
-  <link name='base_link'>
-    <inertial>
-      <mass value='0.1' />
-      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
-    </inertial>
-    <visual>
-      <geometry>
-        <sphere radius="2"/>
-      </geometry>
-    </visual>
-  </link>
-  <gazebo reference='base_link'>
-    <material>Gazebo/Orange</material>
-  </gazebo>
-</robot>
-
-```
+<include src='https://github.com/azeey/sdf_tutorials/raw/urdf_sdf_extension/urdf/examples/link_ref_example.urdf' />
 
 results in:
 
@@ -412,8 +380,8 @@ tags in the **URDF** file have names.
 When using the `<gazebo>` extension for joints, the name of the joint has to be
 specified in the `reference` attribute. There are a number of special tags that
 modify the values of elements or attributes in the generated SDFormat file. Any
-tag that is not listed in the table below will be directly inserted into the
-the corresponding `<joint>` element in the SDFormat output.
+tag that is not listed in the table below will be directly inserted into the 
+corresponding `<joint>` element in the SDFormat output.
 
 
 **Table of elements with special meaning:**
@@ -490,32 +458,7 @@ the corresponding `<joint>` element in the SDFormat output.
 The spring reference and stiffness of a joint can be set using
 `<springReference>` and `<springStiffness>` respectively.
 
-```xml
-<!--URDF-->
-<robot name='joint_example'>
-  <link name='base_link'>
-    <inertial>
-      <mass value='0.12' />
-      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
-    </inertial>
-  </link>
-  <joint name='j1' type='continuous'>
-    <parent link='base_link'/>
-    <child link='end_effector'/>
-    <origin xyz='0 0 1' rpy='0 0 0'/>
-  </joint>
-  <link name='end_effector'>
-    <inertial>
-      <mass value='0.12' />
-      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
-    </inertial>
-  </link>
-  <gazebo reference='j1'>
-    <springReference>0.5</springReference>
-    <springStiffness>0.25</springStiffness>
-  </gazebo>
-</robot>
-```
+<include src='https://github.com/azeey/sdf_tutorials/raw/urdf_sdf_extension/urdf/examples/joint_example.urdf' />
 
 This creates the elements `//axis/dynamics/spring_reference`
 and `//axis/dynamics//spring_stiffness` in the referenced joint
@@ -607,44 +550,11 @@ corresponding `<inertial>` elements.
 **Example:** The following URDF demonstrates fixed joint lumping where the
 resulting SDFormat output only has one link
 
-```xml
-<!--URDF-->
-<robot name='fixed_joint_lumping_example'>
-  <link name='base_link'>
-    <inertial>
-      <mass value='0.25' />
-      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
-    </inertial>
-    <collision>
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-      <geometry>
-        <sphere radius="2"/>
-      </geometry>
-    </collision>
-  </link>
-  <joint name='j1' type='fixed'>
-    <parent link='base_link'/>
-    <child link='end_effector'/>
-    <origin xyz='0 0 1' rpy='0 0 0'/>
-  </joint>
-  <link name='end_effector'>
-    <inertial>
-      <mass value='0.25' />
-      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
-    </inertial>
-    <visual>
-      <origin xyz="2 0 0" rpy="0 0 0"/>
-      <geometry>
-        <cylinder length="1" radius="2"/>
-      </geometry>
-    </visual>
-  </link>
-</robot>
-```
+<include src='https://github.com/azeey/sdf_tutorials/raw/urdf_sdf_extension/urdf/examples/fixed_joint_lumping_example.urdf' />
 
 results in:
 
-```xml 
+```xml
 <!--SDFormat-->
 <sdf version='1.9'>
   <model name='fixed_joint_lumping_example'>
@@ -696,43 +606,7 @@ the original `visual`.
 **Example:** The same example above is repeated, but with fixed joint lumping
 disabled (`disableFixedJointLumping=true`).
 
-```xml
-<!--URDF-->
-<robot name='disable_fixed_joint_lumping_example'>
-  <link name='base_link'>
-    <inertial>
-      <mass value='0.25' />
-      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
-    </inertial>
-    <collision>
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-      <geometry>
-        <sphere radius="2"/>
-      </geometry>
-    </collision>
-  </link>
-  <joint name='j1' type='fixed'>
-    <parent link='base_link'/>
-    <child link='end_effector'/>
-    <origin xyz='0 0 1' rpy='0 0 0'/>
-  </joint>
-  <link name='end_effector'>
-    <inertial>
-      <mass value='0.25' />
-      <inertia ixx='0.01' ixy='0' ixz='0' iyy='0.01' iyz='0' izz='0.01' />
-    </inertial>
-    <visual>
-      <origin xyz="2 0 0" rpy="0 0 0"/>
-      <geometry>
-        <cylinder length="1" radius="2"/>
-      </geometry>
-    </visual>
-  </link>
-  <gazebo reference='j1'>
-    <disableFixedJointLumping>true</disableFixedJointLumping>
-  </gazebo>
-</robot>
-```
+<include src='https://github.com/azeey/sdf_tutorials/raw/urdf_sdf_extension/urdf/examples/disable_fixed_joint_lumping_example.urdf' />
 
 results in:
 


### PR DESCRIPTION
There is good documentation for the `<gazebo>` tag at https://classic.gazebosim.org/tutorials?tut=ros_urdf&cat=connect_ros, but it is presented in a tutorial format and is missing some concepts and explanations. This is an attempt to document the current behavior and provide an explanation about fixed joint lumping.


[Preview](http://sdformat.org/tutorials?tut=sdformat_urdf_extensions&cat=specification&branch=urdf_sdf_extension&repo=https%3A%2F%2Fgithub.com%2Fazeey%2Fsdf_tutorials)