### PR TITLE
Fix broken links to gz-usd

### DIFF
--- a/interoperability_formats/tutorial.md
+++ b/interoperability_formats/tutorial.md
@@ -1,6 +1,6 @@
 # Interoperability with other modeling formats
 
-SDFormat can interoperate with other formats, in particular with [USD](https://graphics.pixar.com/usd/release/index.html)
+SDFormat can interoperate with other formats, in particular with [USD](https://openusd.org/release/index.html)
 and [MJCF](https://mujoco.readthedocs.io/en/latest/modeling.html).
 We have created command line tools to convert between these formats.
 The tools take as input SDFormat files that works in Gazebo Sim and produce as output a MJCF/USD files
@@ -10,8 +10,8 @@ that work in Mujoco/NVIDIA Omniverse with approximately equivalent results; and 
 
 [gz-usd](https://github.com/gazebosim/gz-usd) provides tools to convert between SDF and USD files.
 
- - [How to install gz-usd](https://github.com/gazebosim/gz-usd/tree/ahcorde/update/readme#requirements)
- - [Tutorials](https://github.com/gazebosim/gz-usd/blob/ahcorde/update/readme/tutorials/convert_sdf_to_usd.md)
+ - [How to install gz-usd](https://github.com/gazebosim/gz-usd#requirements)
+ - [Tutorials](https://github.com/gazebosim/gz-usd/blob/main/tutorials/convert_sdf_to_usd.md)
 
 ## MJCF
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Updated invalid [`gz-usd`](https://github.com/gazebosim/gz-usd) links from a deleted branch to `main`. Furthermore, updated the link to the new homepage of USD (OpenUSD).


## Checklist
- [x] Signed all commits for DCO

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
