### PR TITLE
Fix link to anchor (sdf -> sdformat)

### DIFF
--- a/pose_frame_semantics/tutorial.md
+++ b/pose_frame_semantics/tutorial.md
@@ -36,7 +36,7 @@ and one revolute joint is used to illustrate these new features.
 ### Specifying relative poses with `//pose/@relative_to`
 
 SDFormat 1.6 and earlier have
-[fixed rules for each type of element](/tutorials?tut=pose_frame_semantics&ver=1.5#parent-frames-in-sdf-1-4)
+[fixed rules for each type of element](/tutorials?tut=pose_frame_semantics&ver=1.5#parent-frames-in-sdformat-1-4)
 to determine the frame in which a pose is specified. For example, all link
 poses are specified relative to the model frame. This is illustrated for the
 pendulum with base model in SDFormat 1.6 format.


### PR DESCRIPTION
# 🦟 Bug fix

Fixes first link under http://sdformat.org/tutorials?tut=pose_frame_semantics&cat=specification&branch=scpeters/fix_link_to_anchor#specifying-relative-poses-with-pose-relative_to to point to the correct anchor in the page

## Summary

Some instances of "sdf" were replaces with "SDFormat" in #75, and in one case this changed an section heading and its corresponding anchor name, so fix the link to that anchor.

### Reproduce incorrect behavior:

To see the incorrect behavior, go to the following page and click the link with text "fixed rules for each element type":

* http://sdformat.org/tutorials?tut=pose_frame_semantics&cat=specification

That link points to https://gazebosim.github.io/sdf_tutorials/tutorials?tut=pose_frame_semantics&ver=1.5#parent-frames-in-sdf-1-4 which has an incorrect anchor `#parent-frames-in-sdf-1-4`

### Verify fixed behavior:

Click the "fixed rules for each element type" link at the following page rendered from this branch:

* http://sdformat.org/tutorials?tut=pose_frame_semantics&cat=specification&branch=scpeters/fix_link_to_anchor

The link should now point to http://sdformat.org/tutorials?branch=scpeters%2Ffix_link_to_anchor&tut=pose_frame_semantics&ver=1.5#parent-frames-in-sdformat-1-4 and jump to the correct part of the page


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
