### PR TITLE
Fix redirection of spec pages

### DIFF
--- a/content/assets/javascripts/redirect_old_links.js.erb
+++ b/content/assets/javascripts/redirect_old_links.js.erb
@@ -12,7 +12,7 @@ $(function redirect_old_links() {
 
   var new_loc = null
 
-  if (url.pathname = "/spec/" && spec_re.test(url.search)) {
+  if (url.pathname == "/spec/" && spec_re.test(url.search)) {
     var ver = params.get('ver');
     var elem = params.get('elem');
     if (ver && elem) {


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Redirection of spec pages is not currently working because of some a logic error in the code. The `/spec` string is part of the url path not the search paramters, so the regex match was faling. The `if` block that handles the resulting `new_loc` variable was also in the wrong scope.

Test with: 
http://sdformat.org/spec/?ver=1.12&elem=collision

http://localhost:3000/spec/?ver=1.12&elem=collision

Note that, testing redirection with `nanoc live` doesn't work all the time. If the `/` is missing right after `spec`, the server doesn't seem to add that, but testing with `python3 -m http.server 3000` shows that the redirection works with and without the added `/`, i.e, both http://localhost:3000/spec/?ver=1.12&elem=collision and http://localhost:3000/spec?ver=1.12&elem=collision work.


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
